### PR TITLE
Adds support to read the ?fxhash from the URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
     <title>FXHASH project</title>
     <script id="fxhash-snippet">
       //---- do not edit the following code (you can indent as you wish)
+      let search = new URLSearchParams(window.location.search)
       let alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
-      var fxhash = "oo" + Array(49).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
+      var fxhash = search.get('fxhash') || "oo" + Array(49).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
       let b58dec = str=>[...str].reduce((p,c)=>p*alphabet.length+alphabet.indexOf(c)|0, 0)
       let fxhashTrunc = fxhash.slice(2)
       let regex = new RegExp(".{" + ((fxhash.length/4)|0) + "}", 'g')


### PR DESCRIPTION
The webpack boilerplate provides a feature that allows you to test fxhash locally: https://github.com/fxhash/fxhash-webpack-boilerplate/blob/master/public/index.html#L10

This PR adds the same feature to the Simple Boilerplate by first checking the URL for a hash, or creating a random one if it doesn't exist